### PR TITLE
Fixed simulator Publish error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /vendor/
 /bin/
 /composer.phar
+/nbproject/private/

--- a/src/EUREKA/G6KBundle/Controller/SimulatorsAdminController.php
+++ b/src/EUREKA/G6KBundle/Controller/SimulatorsAdminController.php
@@ -1011,7 +1011,7 @@ class SimulatorsAdminController extends BaseAdminController {
 				libxml_clear_errors();
 				return $response;
 			} else {
-				$fs->copy($this->simulatorsDir . "/work/" . $this->simulatorsDir . ".xml", $this->simulatorsDir . "/" . $simu . ".xml");
+				$fs->copy($this->simulatorsDir . "/work/" . $simu . ".xml", $this->simulatorsDir . "/" . $simu . ".xml");
 				return new RedirectResponse($this->generateUrl('eureka_g6k_admin_simulator', array('simulator' => $simu)));
 			}
 		}


### PR DESCRIPTION
The error (shown in the attached image) when publishing a simulator no longer displays thanks to this modification.
And now, the simulator that is in the _work_ directory is indeed copied in the _simulators_ directory.

![error_no_longer_displayed](https://user-images.githubusercontent.com/14300737/31083810-fa679efe-a792-11e7-9ed5-8789e3674c22.PNG)
